### PR TITLE
change rzap depend from local to remote

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,79 @@
+name: Rust CI and Release
+on:
+  push:
+    branches: ["main"]
+    tags:
+      - "v*"
+      - "release"
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: write # This gives write access to create releases and upload assets
+
+env:
+  CARGO_TERM_COLOR: always
+  BINARY_NAME: openshock-tui
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        rust: [stable]
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            suffix: ""
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            suffix: ""
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            suffix: ".exe"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+      - name: Run tests
+        run: cargo test --verbose
+      - name: Verify CLI functionality
+        run: |
+          cargo run -- 5 plus 3
+          cargo run -- 4 squared
+      - name: Prepare artifact
+        run: |
+          mkdir -p artifacts
+          cp target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}${{ matrix.suffix }} artifacts/${{ env.BINARY_NAME }}-${{ matrix.target }}${{ matrix.suffix }}
+        shell: bash
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BINARY_NAME }}-${{ matrix.target }}
+          path: artifacts/${{ env.BINARY_NAME }}-${{ matrix.target }}${{ matrix.suffix }}
+
+  release:
+    needs: build
+    if: github.ref == 'refs/tags/release'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            artifacts/*
+          generate_release_notes: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,30 +7,21 @@ on:
       - "release"
   pull_request:
     branches: ["main"]
-
 permissions:
-  contents: write # This gives write access to create releases and upload assets
-
+  contents: write
 env:
   CARGO_TERM_COLOR: always
   BINARY_NAME: openshock-tui
-
 jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         rust: [stable]
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             suffix: ""
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            suffix: ""
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            suffix: ".exe"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +50,6 @@ jobs:
         with:
           name: ${{ env.BINARY_NAME }}-${{ matrix.target }}
           path: artifacts/${{ env.BINARY_NAME }}-${{ matrix.target }}${{ matrix.suffix }}
-
   release:
     needs: build
     if: github.ref == 'refs/tags/release'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,15 +36,17 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }}
       - name: Run tests
         run: cargo test --verbose
+      - name: Create output directory
+        run: mkdir -p target/debug
       - name: Verify CLI functionality
         run: |
-          cargo run -- 5 plus 3
-          cargo run -- 4 squared
+          cargo build
+          ./target/debug/${{ env.BINARY_NAME }} 5 plus 3
+          ./target/debug/${{ env.BINARY_NAME }} 4 squared
       - name: Prepare artifact
         run: |
           mkdir -p artifacts
           cp target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}${{ matrix.suffix }} artifacts/${{ env.BINARY_NAME }}-${{ matrix.target }}${{ matrix.suffix }}
-        shell: bash
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 crossterm = "0.28.1"
 dotenvy = "0.15.7"
 ratatui = "0.28.1"
-rzap = {path ="../rzap"}
+rzap = "0.2.1"
 tokio = "1.40.0"
 tui-textarea = "0.6.1"


### PR DESCRIPTION
Unless I am missing context as to why it is local it makes more sense to make it be grabbed from remote instead of relying on the person compiling to take care of it locally